### PR TITLE
New Option: silence_output to supress any stdout/stderr messages from ClamAV

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Setting the `fdpass` configuration option to `true` will pass the `--fdpass` opt
       :error_clamscan_missing => false,
       :error_file_missing => false,
       :error_file_virus => false,
-      :fdpass => false
+      :fdpass => false,
+      :silence_output => false
     })
 ```
 

--- a/lib/clamby.rb
+++ b/lib/clamby.rb
@@ -8,7 +8,8 @@ module Clamby
     :error_clamscan_missing => true,
     :error_file_missing => true,
     :error_file_virus => false,
-    :fdpass => false
+    :fdpass => false,
+    :silence_output => false
   }
 
   @valid_config_keys = @config.keys
@@ -32,6 +33,7 @@ module Clamby
       cmd << '--fdpass' if @config[:fdpass]
       cmd << path
       cmd << '--no-summary'
+      cmd << { out: File::NULL } if @config[:silence_output]
     end
     command
   end
@@ -49,7 +51,7 @@ module Clamby
 
   def self.scanner_exists?
     return true unless @config[:check]
-    scanner = system(clamd_executable_name, '-V')
+    scanner = system(clamd_executable_name, '-V', @config[:silence_output] ? { out: File::NULL } : {})
 
     return true if scanner
     return false unless @config[:error_clamscan_missing]
@@ -70,7 +72,7 @@ module Clamby
   end
 
   def self.update
-    system("freshclam")
+    system("freshclam", @config[:silence_output] ? { out: File::NULL } : {})
   end
 
   def self.config


### PR DESCRIPTION
If nobody processes the output anyway, it just spams in test runs or production logs.

So, i've added the option { silence_output: false } which supresses that redirecting stdout to dev/null (platform independent by Ruby's File::NULL)
