### PR TITLE
Add stream option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Setting the `fdpass` configuration option to `true` will pass the `--fdpass` opt
 
 `--fdpass : Pass the file descriptor permissions to clamd. This is useful if clamd is running as a different user as it is faster than streaming the file to clamd. Only available if connected to clamd via local(unix) socket.`
 
+Setting the `stream` configuration option will stream the file to the daemon. This may be useful for forcing streaming as a test for local development. Only works when also specifying `daemonize`. From the clamdscan man page:
+
+`--stream : Forces file streaming to clamd. This is generally not needed as clamdscan detects automatically if streaming is required. This option only exists for debugging and testing purposes, in all other cases --fdpass is preferred.`
+
 ```ruby
     Clamby.configure({
       :check => false,
@@ -82,7 +86,8 @@ Setting the `fdpass` configuration option to `true` will pass the `--fdpass` opt
       :error_file_missing => false,
       :error_file_virus => false,
       :fdpass => false,
-      :silence_output => false
+      :silence_output => false,
+      :stream => false
     })
 ```
 

--- a/lib/clamby.rb
+++ b/lib/clamby.rb
@@ -1,16 +1,18 @@
 require "clamby/version"
 require "clamby/exception"
 module Clamby
-
-  @config = {
+  DEFAULT_CONFIG = {
     :check => true,
     :daemonize => false,
     :error_clamscan_missing => true,
     :error_file_missing => true,
     :error_file_virus => false,
     :fdpass => false,
-    :silence_output => false
-  }
+    :silence_output => false,
+    :stream => false
+  }.freeze
+
+  @config = DEFAULT_CONFIG.dup
 
   @valid_config_keys = @config.keys
 
@@ -31,6 +33,7 @@ module Clamby
     command = [].tap do |cmd|
       cmd << clamd_executable_name
       cmd << '--fdpass' if @config[:fdpass]
+      cmd << '--stream' if @config[:stream] && @config[:daemonize]
       cmd << path
       cmd << '--no-summary'
       cmd << { out: File::NULL } if @config[:silence_output]


### PR DESCRIPTION
We wanted to have the `--stream` option from `clamdscan` available (similar to the the `--fdpass` option) for testing, so I added it. To make the tests work, I also made the defaults a constant and reset them in each test. Without this, the configuration from the `--fdpass` tests was leaking into the `--stream` tests.

Hope that's ok! Happy to try other options. :smile: 