### PR TITLE
Add config file option for clamdscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Configuration is rather limited right now. You can exclude the check if `clamsca
     Clamby.configure({
       :check => false,
       :daemonize => false,
+      :config_file => nil,
       :error_clamscan_missing => false,
       :error_file_missing => false,
       :error_file_virus => false,
@@ -84,6 +85,8 @@ Configuration is rather limited right now. You can exclude the check if `clamsca
 #### Daemonize
 
 I highly recommend using the `daemonize` set to true. This will allow for clamscan to remain in memory and will not have to load for each virus scan. It will save several seconds per request.
+
+To specify a config file for clamdscan to use, you can set `config_file` with the relevant path. See [this page](https://linux.die.net/man/5/clamd.conf) for more information about the config file.
 
 #### Error suppression
 

--- a/lib/clamby.rb
+++ b/lib/clamby.rb
@@ -7,6 +7,7 @@ module Clamby
   DEFAULT_CONFIG = {
     :check => true,
     :daemonize => false,
+    :config_file => nil,
     :error_clamscan_missing => true,
     :error_clamscan_client_error => false,
     :error_file_missing => true,

--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -21,6 +21,7 @@ module Clamby
       if Clamby.config[:daemonize]
         args << '--fdpass' if Clamby.config[:fdpass]
         args << '--stream' if Clamby.config[:stream]
+        args << "--config-file=#{Clamby.config[:config_file]}" if Clamby.config[:config_file] && Clamby.config[:daemonize]
       end
 
       new.run scan_executable, *args

--- a/spec/clamby/command_spec.rb
+++ b/spec/clamby/command_spec.rb
@@ -75,5 +75,36 @@ describe Clamby::Command do
         described_class.scan(good_path)
       end
     end
+
+    describe 'specifying config-file' do
+      it 'does not include the parameter in the clamscan command by default' do
+        Clamby.configure(daemonize: false, stream: false, fdpass: false)
+        expect(runner).to receive(:run).with('clamscan', good_path, '--no-summary')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+      it 'does not include the parameter in the clamdscan command by default' do
+        Clamby.configure(daemonize: true, stream: false, fdpass: false)
+        expect(runner).to receive(:run).with('clamdscan', good_path, '--no-summary')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+      it 'omits the parameter when invoking clamscan if it is set' do
+        Clamby.configure(daemonize: false, stream: false, fdpass: false, config_file: 'clamd.conf')
+        expect(runner).to receive(:run).with('clamscan', good_path, '--no-summary')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+      it 'passes the parameter when invoking clamdscan if it is set' do
+        Clamby.configure(daemonize: true, stream: false, fdpass: false, config_file: 'clamd.conf')
+        expect(runner).to receive(:run).with('clamdscan', good_path, '--no-summary', '--config-file=clamd.conf')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey,

This was something that we needed for our project as we're running clamav in a weird environment where we don't have read access to the default `clamd.conf` file. There are docs about the option [here](https://linux.die.net/man/1/clamdscan) and [here](https://linux.die.net/man/5/clamd.conf). Let me know if there's anything you'd like me to tweak!

Thanks for making a really useful library! 😄 