### PR TITLE
Move exception classes into Clamby module

### DIFF
--- a/lib/clamby.rb
+++ b/lib/clamby.rb
@@ -1,6 +1,6 @@
 require "English"
 require "clamby/command"
-require "clamby/exception"
+require "clamby/error"
 require "clamby/version"
 
 module Clamby
@@ -52,7 +52,7 @@ module Clamby
     return true if scanner
     return false unless config[:error_clamscan_missing]
 
-    raise Exceptions::ClamscanMissing.new("#{Command.scan_executable} not found. Check your installation and path.")
+    raise Clamby::ClamscanMissing.new("#{Command.scan_executable} not found. Check your installation and path.")
   end
 
   def self.update

--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -31,7 +31,7 @@ module Clamby
       when 2
         # clamdscan returns 2 whenever error other than a detection happens
         if Clamby.config[:error_clamscan_client_error] && Clamby.config[:daemonize]
-          raise Exceptions::ClamscanClientError.new("Clamscan client error")
+          raise Clamby::ClamscanClientError.new("Clamscan client error")
         end
 
         # returns true to maintain legacy behavior
@@ -39,7 +39,7 @@ module Clamby
       else
         return true unless Clamby.config[:error_file_virus]
 
-        raise Exceptions::VirusDetected.new("VIRUS DETECTED on #{Time.now}: #{path}")
+        raise Clamby::VirusDetected.new("VIRUS DETECTED on #{Time.now}: #{path}")
       end
     end
 
@@ -91,7 +91,7 @@ module Clamby
       return true if File.file?(path)
 
       if Clamby.config[:error_file_missing]
-        raise Exceptions::FileNotFound.new("File not found: #{path}")
+        raise Clamby::FileNotFound.new("File not found: #{path}")
       else
         puts "FILE NOT FOUND on #{Time.now}: #{path}"
         return false

--- a/lib/clamby/error.rb
+++ b/lib/clamby/error.rb
@@ -1,5 +1,6 @@
-module Exceptions
+module Clamby
   class Error < StandardError; end
+
   class VirusDetected < Error; end
   class ClamscanMissing < Error; end
   class ClamscanClientError < Error; end

--- a/spec/clamby/command_spec.rb
+++ b/spec/clamby/command_spec.rb
@@ -19,7 +19,7 @@ describe Clamby::Command do
 
         expect do
           described_class.scan(bad_path)
-        end.to raise_exception(Exceptions::FileNotFound)
+        end.to raise_exception(Clamby::FileNotFound)
       end
       it 'can be configured to return false when file is missing' do
         Clamby.configure({:error_file_missing => false})

--- a/spec/clamby_spec.rb
+++ b/spec/clamby_spec.rb
@@ -32,8 +32,8 @@ describe Clamby do
 
     dangerous = Tempfile.new
     Clamby.configure({:error_file_virus => true})
-    expect{Clamby.safe?(dangerous)}.to raise_exception(Exceptions::VirusDetected)
-    expect{Clamby.virus?(dangerous)}.to raise_exception(Exceptions::VirusDetected)
+    expect{Clamby.safe?(dangerous)}.to raise_exception(Clamby::VirusDetected)
+    expect{Clamby.virus?(dangerous)}.to raise_exception(Clamby::VirusDetected)
     Clamby.configure({:error_file_virus => false})
     expect(Clamby.safe?(dangerous)).to be false
     expect(Clamby.virus?(dangerous)).to be true
@@ -101,7 +101,7 @@ describe Clamby do
 
       it 'virus? raises when the daemonized client exits with status 2' do
         Clamby.configure(daemonize: true)
-        expect { Clamby.virus?(good_path) }.to raise_error(Exceptions::ClamscanClientError)
+        expect { Clamby.virus?(good_path) }.to raise_error(Clamby::ClamscanClientError)
       end
       it 'returns true when the client exits with status 2' do
         Clamby.configure(daemonize: false)


### PR DESCRIPTION
I believe that defining exceptions in `Exceptions` module is not a good practice because it pollutes the global namespace.

This PR moves exception classes into `Clamby` module.