### PR TITLE
Remove unnecessary check

### DIFF
--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -21,7 +21,7 @@ module Clamby
       if Clamby.config[:daemonize]
         args << '--fdpass' if Clamby.config[:fdpass]
         args << '--stream' if Clamby.config[:stream]
-        args << "--config-file=#{Clamby.config[:config_file]}" if Clamby.config[:config_file] && Clamby.config[:daemonize]
+        args << "--config-file=#{Clamby.config[:config_file]}" if Clamby.config[:config_file]
       end
 
       new.run scan_executable, *args


### PR DESCRIPTION
The `daemonize` config is already checked in the if clause above, so a double check is not needed.