### PR TITLE
New feature: allow configuring executable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ Configuration is rather limited right now. You can exclude the check if `clamsca
       :error_file_virus => false,
       :fdpass => false,
       :stream => false,
-      :output => 'medium' # one of 'off', 'low', 'medium', 'high'
+      :output => 'medium', # one of 'off', 'low', 'medium', 'high'
+      :executable_path_clamscan => 'clamscan',
+      :executable_path_clamdscan => 'clamdscan',
+      :executable_path_freshclam => 'freshclam',
     })
 ```
 
@@ -111,6 +114,22 @@ Setting the `stream` configuration option will stream the file to the daemon. Th
 - *low*: show errors, but nothing else
 - *medium*: show errors and briefly what happened _(default)_
 - *high*: as verbose as possible
+
+#### Executable paths
+
+Setting any of the executable paths makes Clamby to use those paths instead of
+the defaults for the system calls. The default configuration for these should be
+perfectly fine for most use cases but it may be required to configure custom
+paths in case ClamAV is manually installed to a custom location.
+
+In order to configure the paths, use the following configuration options:
+
+- *executable_path_clamscan*: defines the executable path for the `clamscan`
+  executable, defaults to `clamscan`
+- *executable_path_clamdscan*: defines the executable path for the `clamdscan`
+  executable, defaults to `clamdscan`
+- *executable_path_freshclam*: defines the executable path for the `freshclam`
+  executable, defaults to `freshclam`
 
 # Dependencies
 

--- a/lib/clamby.rb
+++ b/lib/clamby.rb
@@ -14,7 +14,10 @@ module Clamby
     :error_file_virus => false,
     :fdpass => false,
     :stream => false,
-    :output_level => 'medium'
+    :output_level => 'medium',
+    :executable_path_clamscan => 'clamscan',
+    :executable_path_clamdscan => 'clamdscan',
+    :executable_path_freshclam => 'freshclam',
   }.freeze
 
   @config = DEFAULT_CONFIG.dup

--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -63,9 +63,9 @@ module Clamby
     #   run('clamscan', file, '--verbose')
     #   run('clamscan', '-V')
     def run(executable, *args)
-      raise "`#{executable}` is not permitted" unless EXECUTABLES.include?(executable)
+      executable_full = executable_path(executable)
       self.command = args | default_args
-      self.command = command.sort.unshift(executable)
+      self.command = command.sort.unshift(executable_full)
 
       system(*self.command, system_options)
     end
@@ -86,6 +86,11 @@ module Clamby
       else
         {}
       end
+    end
+
+    def executable_path(executable)
+      raise "`#{executable}` is not permitted" unless EXECUTABLES.include?(executable)
+      Clamby.config[:"executable_path_#{executable}"]
     end
 
     def self.file_exists?(path)

--- a/spec/clamby/command_spec.rb
+++ b/spec/clamby/command_spec.rb
@@ -114,5 +114,58 @@ describe Clamby::Command do
         described_class.scan(good_path)
       end
     end
+
+    describe 'specifying custom executable paths' do
+      let(:runner) { described_class.new }
+      let(:custom_path) { '/custom/path' }
+
+      before do
+        Clamby.configure(
+          executable_path_clamscan: "#{custom_path}/clamscan",
+          executable_path_clamdscan: "#{custom_path}/clamdscan",
+          executable_path_freshclam: "#{custom_path}/freshclam",
+        )
+        allow(described_class).to receive(:new).and_return(runner)
+      end
+
+      it 'executes the freshclam executable from the custom path' do
+        expect(runner).to receive(:system).with(
+          "#{custom_path}/freshclam",
+          {}
+        ) { system("exit 0", out: File::NULL) }
+
+        described_class.freshclam
+      end
+
+      context 'when not set with daemonize' do
+        before { Clamby.configure(daemonize: false) }
+
+        it 'executes the clamscan executable from the custom path' do
+          expect(runner).to receive(:system).with(
+            "#{custom_path}/clamscan",
+            '--no-summary',
+            good_path,
+            {}
+          ) { system("exit 0", out: File::NULL) }
+
+          described_class.scan(good_path)
+        end
+      end
+
+      context 'when set with daemonize' do
+        before { Clamby.configure(daemonize: true) }
+
+        it 'executes the clamdscan executable from the custom path' do
+          expect(runner).to receive(:system).with(
+            "#{custom_path}/clamdscan",
+            '--no-summary',
+            good_path,
+            {}
+          ) { system("exit 0", out: File::NULL) }
+
+          described_class.scan(good_path)
+        end
+      end
+    end
   end
 end

--- a/spec/clamby_spec.rb
+++ b/spec/clamby_spec.rb
@@ -107,4 +107,39 @@ describe Clamby do
       end
     end
   end
+
+  context 'executable paths' do
+    context 'executable_path_clamscan option' do
+      it 'is clamscan by default' do
+        expect(Clamby.config[:executable_path_clamscan]).to eq 'clamscan'
+      end
+      it 'accepts an executable_path_clamscan option in the config' do
+        path = '/custom/path/clamscan'
+        Clamby.configure(executable_path_clamscan: path)
+        expect(Clamby.config[:executable_path_clamscan]).to eq path
+      end
+    end
+
+    context 'executable_path_clamdscan option' do
+      it 'is clamdscan by default' do
+        expect(Clamby.config[:executable_path_clamdscan]).to eq 'clamdscan'
+      end
+      it 'accepts an executable_path_clamdscan option in the config' do
+        path = '/custom/path/clamdscan'
+        Clamby.configure(executable_path_clamdscan: path)
+        expect(Clamby.config[:executable_path_clamdscan]).to eq path
+      end
+    end
+
+    context 'executable_path_freshclam option' do
+      it 'is freshclam by default' do
+        expect(Clamby.config[:executable_path_freshclam]).to eq 'freshclam'
+      end
+      it 'accepts an executable_path_freshclam option in the config' do
+        path = '/custom/path/freshclam'
+        Clamby.configure(executable_path_freshclam: path)
+        expect(Clamby.config[:executable_path_freshclam]).to eq path
+      end
+    end
+  end
 end


### PR DESCRIPTION
In some occasions it is needed to run the ClamAV executables from a custom path when the executables are not available in the system's or user's PATH.

This adds the possibility to configure these using the new configuration options.