### PR TITLE
Fix invalid configuration key in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Configuration is rather limited right now. You can exclude the check if `clamsca
       :error_file_virus => false,
       :fdpass => false,
       :stream => false,
-      :output => 'medium', # one of 'off', 'low', 'medium', 'high'
+      :output_level => 'medium', # one of 'off', 'low', 'medium', 'high'
       :executable_path_clamscan => 'clamscan',
       :executable_path_clamdscan => 'clamdscan',
       :executable_path_freshclam => 'freshclam',


### PR DESCRIPTION
The configuration key named `ouput` does not work.

Fix this to the documentation.