### PR TITLE
Handle system() failing to execute client

### DIFF
--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -25,10 +25,12 @@ module Clamby
 
       new.run scan_executable, *args
 
-      case $CHILD_STATUS.exitstatus
+      # $CHILD_STATUS maybe nil if the execution itself (not the client process)
+      # fails
+      case $CHILD_STATUS && $CHILD_STATUS.exitstatus
       when 0
         return false
-      when 2
+      when nil, 2
         # clamdscan returns 2 whenever error other than a detection happens
         if Clamby.config[:error_clamscan_client_error] && Clamby.config[:daemonize]
           raise Clamby::ClamscanClientError.new("Clamscan client error")


### PR DESCRIPTION
In production, we've seen `$CHILD_STATUS` be nil and thus the call to `#exitstatus` fail. If I'm reading this correctly - https://ruby-doc.org/core-2.2.3/Process/Status.html - this might happen if the underlying `exec()` (or possibly `fork()`?) call fails, so this treats it the same as if the client fails.

We could also break this out into a different error class if people find that valuable.