### PR TITLE
Allow for special characters in file names / paths

### DIFF
--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -16,7 +16,7 @@ module Clamby
     def self.scan(path)
       return nil unless file_exists?(path)
 
-      args = [path, '--no-summary']
+      args = [Shellwords.escape(path), '--no-summary']
 
       if Clamby.config[:daemonize]
         args << '--fdpass' if Clamby.config[:fdpass]


### PR DESCRIPTION
This escapes the file path provided so that special characters do now break the command. For example: `test_file_with(parentheses).png` or `test_file_with space.png`