### PR TITLE
Allow paths to be escaped

### DIFF
--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -16,7 +16,7 @@ module Clamby
     def self.scan(path)
       return nil unless file_exists?(path)
 
-      args = [path, '--no-summary']
+      args = [Shellwords.escape(path), '--no-summary']
 
       if Clamby.config[:daemonize]
         args << '--fdpass' if Clamby.config[:fdpass]

--- a/spec/clamby/command_spec.rb
+++ b/spec/clamby/command_spec.rb
@@ -155,5 +155,11 @@ describe Clamby::Command do
         end
       end
     end
+
+    describe 'special filenames' do
+      it 'does not fail' do
+        expect(described_class.scan(special_path)).to be(false)
+      end
+    end
   end
 end

--- a/spec/fixtures/safe (special).txt
+++ b/spec/fixtures/safe (special).txt
@@ -1,0 +1,2 @@
+This is a virus-free file.
+It is used by automated tests.

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,4 +1,5 @@
 RSpec.shared_context 'paths' do
+  let(:special_path) { File.expand_path('../../fixtures/safe (special).txt', __FILE__) }
   let(:good_path) { File.expand_path('../../fixtures/safe.txt', __FILE__) }
   let(:bad_path) { File.expand_path("not-here/#{rand 10e6}.txt", __FILE__) }
 end


### PR DESCRIPTION
Files / paths with special characters or spaces would fail at the shell. This uses `Shellwords#escape` to ensure they are properly escaped before being passed to the shell.