### PR TITLE
Add clamdscan as explicit dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ In order to configure the paths, use the following configuration options:
 
 ***Ubuntu***
 
-`sudo apt-get install clamav clamav-daemon`
+`sudo apt-get install clamav clamdscan clamav-daemon`
 
 Note, `clamav-daemon` is optional but recommended. It's needed if you wish to
 run ClamAV in daemon mode.


### PR DESCRIPTION
This PR updates the README file to include `clamdscan` as part of the installation instructions.

When running `sudo apt-get install --no-install-recommends clamav clamav-daemon`, `clamdscan` doesn't get installed as its listed only as a recommended package under `clamav-daemon`.