### PR TITLE
Add reload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Configuration is rather limited right now. You can exclude the check if `clamsca
       :error_file_virus => false,
       :fdpass => false,
       :stream => false,
+      :reload => false,
       :output_level => 'medium', # one of 'off', 'low', 'medium', 'high'
       :executable_path_clamscan => 'clamscan',
       :executable_path_clamdscan => 'clamdscan',
@@ -127,6 +128,12 @@ Setting the `fdpass` configuration option to `true` will pass the `--fdpass` opt
 Setting the `stream` configuration option will stream the file to the daemon. This may be useful for forcing streaming as a test for local development. Only works when also specifying `daemonize`. From the clamdscan man page:
 
 `--stream : Forces file streaming to clamd. This is generally not needed as clamdscan detects automatically if streaming is required. This option only exists for debugging and testing purposes, in all other cases --fdpass is preferred.`
+
+#### Force streaming files to clamd
+
+Setting the `reload` configuration option to `true` will pass the `--reload` option  to the daemon. Only works when also specifying `daemonize`. From the clamdscan man page:
+
+`--reload : Request clamd to reload virus database.`
 
 #### Output levels
 

--- a/lib/clamby.rb
+++ b/lib/clamby.rb
@@ -14,6 +14,7 @@ module Clamby
     :error_file_virus => false,
     :fdpass => false,
     :stream => false,
+    :reload => false,
     :output_level => 'medium',
     :datadir => nil,
     :executable_path_clamscan => 'clamscan',

--- a/lib/clamby/command.rb
+++ b/lib/clamby/command.rb
@@ -21,6 +21,7 @@ module Clamby
       if Clamby.config[:daemonize]
         args << '--fdpass' if Clamby.config[:fdpass]
         args << '--stream' if Clamby.config[:stream]
+        args << '--reload' if Clamby.config[:reload]
       end
 
       args << "-d #{Clamby.config[:datadir]}" if Clamby.config[:datadir]

--- a/spec/clamby/command_spec.rb
+++ b/spec/clamby/command_spec.rb
@@ -84,6 +84,32 @@ describe Clamby::Command do
       end
     end
 
+    describe 'reloading virus database' do
+      it 'does not include reload in the command by default' do
+        Clamby.configure
+        expect(runner).to receive(:run).with('clamscan', good_path, '--no-summary')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+
+      it 'omits the reload option when invoking clamscan if it is set, but daemonize isn\'t' do
+        Clamby.configure(reload: true)
+        expect(runner).to receive(:run).with('clamscan', good_path, '--no-summary')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+
+      it 'passes the reload option when invoking clamscan if it is set with daemonize' do
+        Clamby.configure(reload: true, daemonize: true)
+        expect(runner).to receive(:run).with('clamdscan', good_path, '--no-summary', '--reload')
+        allow(described_class).to receive(:new).and_return(runner)
+
+        described_class.scan(good_path)
+      end
+    end
+
     describe 'specifying config-file' do
       it 'does not include the parameter in the clamscan command by default' do
         Clamby.configure

--- a/spec/clamby_spec.rb
+++ b/spec/clamby_spec.rb
@@ -66,6 +66,18 @@ describe Clamby do
     end
   end
 
+  # From the clamscan man page:
+  # Request clamd to reload virus database.
+  context 'reload option' do
+    it 'is false by default' do
+      expect(Clamby.config[:reload]).to eq false
+    end
+    it 'accepts an reload option in the config' do
+      Clamby.configure(reload: true)
+      expect(Clamby.config[:reload]).to eq true
+    end
+  end
+
   context 'error_clamscan_client_error option' do
     it 'is false by default' do
       expect(Clamby.config[:error_clamscan_client_error]).to eq false


### PR DESCRIPTION
This PR adds an option to pass the "--reload" argument to clamdscan. From the clamdscan man page: 
`Request clamd to reload virus database.`